### PR TITLE
Fix extra indentation with line numbers using hljs table

### DIFF
--- a/src/demo/html/slides/_slides.pug
+++ b/src/demo/html/slides/_slides.pug
@@ -9,6 +9,16 @@ section
 		//-
 
 section
+	p Alternative without <code>data-line-numbers</code> but with <code>data-trim</code>
+	br
+	pre.data-trim
+		code.hljs.javascript(style="font-size: 1em").
+			let why = `Because we always want to copy code
+			           during our presentations, right?`
+		//-
+
+
+section
 	h3 Works out of the box
 	pre
 		code.hljs.javascript(data-line-numbers).

--- a/src/plugin/js/functions/do-clipboard.js
+++ b/src/plugin/js/functions/do-clipboard.js
@@ -1,11 +1,29 @@
 export const doClipboard = (options) => {
 
-	let clipboard = options.plaintextonly == true ? 
+	let clipboard = options.plaintextonly == true ?
 	new ClipboardJS(".codeblock > button", {
-		text: function(trigger) { 
+		text: function(trigger) {
 			let code = trigger.nextElementSibling.querySelectorAll('code')[0];
-			return code.innerText.replace(/^\s+|\s+$/g, "")
-		}}) : 
+
+			var table = code.querySelector('table');
+			if (table == null) {
+				return code.innerText.replace(/^\s+|\s+$/g, "")
+			}
+
+			var result = "";
+
+			for (let row of table.rows) {
+				for (let cell of row.cells) {
+					if (cell.className.match("hljs-ln-numbers")) {
+						continue
+					} else {
+						result += (cell.innerText + "\n");
+					}
+				}
+			}
+
+			return result
+		}}) :
 	new ClipboardJS(".codeblock > button", {
 		target({nextElementSibling}) {
 			return nextElementSibling.nextElementSibling.querySelectorAll('code')[0]


### PR DESCRIPTION
Fix #13 ... maybe

This applies the possible fix I mentioned in the issue.

Basically:

- check if a `code` block contains a `table`
- if null: return the same thing as before (since copying was fine without `data-line-numbers`)
- otherwise: iterate over the table appending `innerText` only when appropriate